### PR TITLE
all: replace objdump tests with readelf

### DIFF
--- a/ppc64le/mcount_loc-issue-1102.test
+++ b/ppc64le/mcount_loc-issue-1102.test
@@ -1,19 +1,14 @@
 #!/bin/bash
 
-# % objdump -j __mcount_loc -Dr mcount_loc-issue-1102.OUTPUT.o
+# Verify an __mcount_loc relocation for netlbl_catmap_getlong:
 #
-# mcount_loc-issue-1102.OUTPUT.o:     file format elf64-powerpcle
+# % readelf --wide --relocs mcount_loc-issue-1102.OUTPUT.o | \
+#       awk '/\.rela__mcount_loc/' RS="\n\n" ORS="\n\n"
 #
-#
-# Disassembly of section __mcount_loc:
-#
-# 0000000000000000 <__mcount_loc>:
-#         ...
-# 	                        0: R_PPC64_ADDR64       netlbl_catmap_getlong+0x4
-#
+# Relocation section '.rela__mcount_loc' at offset 0x14d0 contains 1 entry:
+#     Offset             Info             Type               Symbol's Value  Symbol's Name + Addend
+# 0000000000000000  0000000200000026 R_PPC64_ADDR64         0000000000000000 netlbl_catmap_getlong + 4
 
-rela=$(objdump -j __mcount_loc -Dr mcount_loc-issue-1102.OUTPUT.o 2>/dev/null | \
-       awk '$2=="R_PPC64_ADDR64" && $3=="netlbl_catmap_getlong+0x4" { print $3 }' 2>/dev/null)
-
-[[ $rela == "netlbl_catmap_getlong+0x4" ]] && exit 0
-exit 1
+readelf --wide --relocs mcount_loc-issue-1102.OUTPUT.o 2>/dev/null | \
+    awk '/\.rela__mcount_loc/' RS="\n\n" ORS="\n\n" | \
+    grep -q '\<R_PPC64_ADDR64\>.*\<netlbl_catmap_getlong\> + 4$'

--- a/x86_64/mcount_loc-issue-1102.test
+++ b/x86_64/mcount_loc-issue-1102.test
@@ -2,19 +2,13 @@
 
 # Verify an __mcount_loc relocation for netlbl_catmap_getlong:
 #
-# % objdump -j __mcount_loc -Dr mcount_loc-issue-1102.OUTPUT.o
+# % readelf --wide --relocs mcount_loc-issue-1102.OUTPUT.o | \
+#       awk '/\.rela__mcount_loc/' RS="\n\n" ORS="\n\n"
 #
-# mcount_loc-issue-1102.OUTPUT.o:     file format elf64-x86-64
-#
-#
-# Disassembly of section __mcount_loc:
-#
-# 0000000000000000 <__mcount_loc>:
-# 	...
-# 			0: R_X86_64_64	netlbl_catmap_getlong
+# Relocation section '.rela__mcount_loc' at offset 0x840 contains 1 entry:
+#     Offset             Info             Type               Symbol's Value  Symbol's Name + Addend
+# 0000000000000000  0000000200000001 R_X86_64_64            0000000000000000 netlbl_catmap_getlong + 0
 
-rela=$(objdump -j __mcount_loc -Dr mcount_loc-issue-1102.OUTPUT.o 2>/dev/null | \
-       awk '$2=="R_X86_64_64" && $3=="netlbl_catmap_getlong" { print $3 }' 2>/dev/null)
-
-[[ $rela == "netlbl_catmap_getlong" ]] && exit 0
-exit 1
+readelf --wide --relocs mcount_loc-issue-1102.OUTPUT.o 2>/dev/null | \
+    awk '/\.rela__mcount_loc/' RS="\n\n" ORS="\n\n" | \
+    grep -q '\<R_X86_64_64\>.*\<netlbl_catmap_getlong\> + 0$'

--- a/x86_64/zero-page-rela-issue-1064.test
+++ b/x86_64/zero-page-rela-issue-1064.test
@@ -7,8 +7,8 @@ assert_num_funcs 1
 TESTFILE=$(basename "$0")
 OUTFILE=${TESTFILE%.test}.OUTPUT.o
 
-# If the issue #1064 is fixed, 'objdump -r <output_binary.o>' should show
-# R_X86_64_64 relocation like 'empty_zero_page+0x80000000'.
+# If the issue #1064 is fixed, there should be a
+# R_X86_64_64 relocation like 'empty_zero_page + 80000000'.
 # If the issue is present, there will be something like
-# 'empty_zero_page-0x80000000' there instead.
-objdump -r ${OUTFILE} | grep -q -E 'R_X86_64_64\s+empty_zero_page\+0x0*80000000'
+# 'empty_zero_page - 80000000' there instead.
+readelf --wide --relocs zero-page-rela-issue-1064.OUTPUT.o | grep -q -e '\<R_X86_64_64\>.*\<empty_zero_page\> + 80000000$'


### PR DESCRIPTION
Not all versions of binutil's objdump support non-local architectures
(see `objdump --arch` for details).

Tweak a few unit test scripts to use readelf (which seems to have better
arch detection and support) instead.  This will fix these tests to
properly verify *.OUTPUT.o files for non-local arches.

Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>